### PR TITLE
Rename endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ To securely authenticate POST requests to the `nip05api` endpoint, utilize the [
 
 1. **Generate the Base64 Encoded Authentication Event**:
    ```sh
-   export BASE64_AUTH_EVENT=$(nak event --content='' --kind 27235 -t method='POST' -t u='http://nos.social/.well-known/nostr.json' --sec $SECRET_KEY | base64)
+   export BASE64_AUTH_EVENT=$(nak event --content='' --kind 27235 -t method='POST' -t u='http://nos.social/api/names' --sec $SECRET_KEY | base64)
    ```
 
 2. **Testing the Endpoint with Curl**:
    ```sh
-   curl http://localhost:3000/.well-known/nostr.json 
+   curl http://localhost:3000/api/names 
        -H "Host: nos.social" 
        -H "Content-Type: application/json" 
        -H "Authorization: Nostr $BASE64_AUTH_EVENT" 
@@ -74,9 +74,9 @@ To securely authenticate POST requests to the `nip05api` endpoint, utilize the [
 You can also delete an entry using the DELETE method. Here's an example of how to do it using `nak` and `curl`:
 
 ```sh
-export BASE64_AUTH_EVENT=$(nak event --content='' --kind 27235 -t method='DELETE' -t u='http://nos.social/.well-known/nostr.json?name=alice' --sec $SECRET_KEY | base64)
+export BASE64_AUTH_EVENT=$(nak event --content='' --kind 27235 -t method='DELETE' -t u='http://nos.social/.well-known/api/names/alice' --sec $SECRET_KEY | base64)
 
-curl -X DELETE http://localhost:3000/.well-known/nostr.json?name=alice 
+curl -X DELETE http://localhost:3000/api/names/alice 
     -H "Host: nos.social" 
     -H "Content-Type: application/json" 
     -H "Authorization: Nostr $BASE64_AUTH_EVENT"

--- a/src/middlewares/extractNip05Name.js
+++ b/src/middlewares/extractNip05Name.js
@@ -14,7 +14,7 @@ function extractName(req) {
   validateDomain(host);
 
   const nonRootSubdomains = host.split(`.${config.rootDomain}`).find(Boolean);
-  const nameFromQueryOrBody = req.query.name || req.body.name;
+  const nameFromQueryOrBody = req.query.name || req.params.name || req.body.name;
 
   if (nameFromQueryOrBody === "_") {
     return validateAndReturnSubdomain(nonRootSubdomains);

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,7 +3,7 @@ import asyncHandler from "./middlewares/asyncHandler.js";
 import validateSchema from "./middlewares/validateSchema.js";
 import extractNip05Name from "./middlewares/extractNip05Name.js";
 import logger from "./logger.js";
-import { postNip05, nip05QueryName as nip05QueryName } from "./schemas.js";
+import { postNip05, nip05QueryName, nip05ParamsName } from "./schemas.js";
 import nip98Auth from "./middlewares/nip98Auth.js";
 import config from "../config/index.js";
 import { AppError, UNAUTHORIZED_STATUS } from "./errors.js";
@@ -35,7 +35,7 @@ router.get(
 );
 
 router.post(
-  "/.well-known/nostr.json",
+  "/api/names",
   validateSchema(postNip05),
   extractNip05Name,
   nip98Auth(validatePubkey),
@@ -70,8 +70,8 @@ router.post(
 );
 
 router.delete(
-  "/.well-known/nostr.json",
-  validateSchema(nip05QueryName),
+  "/api/names/:name",
+  validateSchema(nip05ParamsName),
   extractNip05Name,
   nip98Auth(validatePubkey),
   asyncHandler("deleteNip05", async (req, res) => {

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -36,3 +36,15 @@ export const nip05QueryName = {
     additionalProperties: false,
   },
 };
+
+export const nip05ParamsName = {
+  target: "params",
+  schema: {
+    type: "object",
+    properties: {
+      name: { type: "string", pattern: namePattern },
+    },
+    required: ["name"],
+    additionalProperties: false,
+  },
+};

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -6,11 +6,11 @@ import { getNip98AuthToken, createUserData } from "./testUtils.js";
 
 const redisClient = await getRedisClient();
 const nip98PostAuthToken = await getNip98AuthToken({
-  url: "http://nos.social/.well-known/nostr.json",
+  url: "http://nos.social/api/names",
   method: "POST",
 });
 const nip98PostAuthTokenDomain = await getNip98AuthToken({
-  url: "http://bob.nos.social/.well-known/nostr.json",
+  url: "http://bob.nos.social/api/names",
   method: "POST",
 });
 
@@ -37,7 +37,7 @@ describe("Nostr NIP 05 API tests", () => {
     const invalidUserData = createUserData({ name: "bo b" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${nip98PostAuthToken}`)
       .send(invalidUserData)
@@ -48,7 +48,7 @@ describe("Nostr NIP 05 API tests", () => {
     const userData = createUserData({ name: "xxx" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${nip98PostAuthToken}`)
       .send(userData)
@@ -65,7 +65,7 @@ describe("Nostr NIP 05 API tests", () => {
 
   it("should include cors header in the response", async () => {
     await request(app)
-      .get("/.well-known/nostr.json")
+      .get("/api/names")
       .set("Host", "nos.social")
       .query({ name: "somename" })
       .expect("Access-Control-Allow-Origin", "*");
@@ -75,7 +75,7 @@ describe("Nostr NIP 05 API tests", () => {
     const userData = createUserData({ name: "bob" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${nip98PostAuthToken}`)
       .send(userData)
@@ -101,7 +101,7 @@ describe("Nostr NIP 05 API tests", () => {
     const userData = createUserData({ name: "_" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "bob.nos.social")
       .set("Authorization", `Nostr ${nip98PostAuthTokenDomain}`)
       .send(userData)
@@ -127,7 +127,7 @@ describe("Nostr NIP 05 API tests", () => {
     const userData = createUserData({ name: "nos" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${nip98PostAuthToken}`)
       .send(userData);
@@ -143,7 +143,7 @@ describe("Nostr NIP 05 API tests", () => {
     const userData = createUserData({ name: "nos" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${nip98PostAuthToken}`)
       .send(userData);
@@ -159,7 +159,7 @@ describe("Nostr NIP 05 API tests", () => {
     const userData = createUserData({ name: "bob" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${nip98PostAuthToken}`)
       .send(userData)
@@ -168,7 +168,7 @@ describe("Nostr NIP 05 API tests", () => {
     userData.data.pubkey = config.servicePubkey.replace("1", "2");
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${nip98PostAuthToken}`)
       .send(userData)
@@ -182,23 +182,22 @@ describe("Nostr NIP 05 API tests", () => {
       const userData = createUserData({ name: "bob" });
 
       await request(app)
-        .post("/.well-known/nostr.json")
+        .post("/api/names")
         .set("Host", "nos.social")
         .set("Authorization", `Nostr ${nip98PostAuthToken}`)
         .send(userData);
 
       nip98DeleteAuthToken = await getNip98AuthToken({
-        url: "http://nos.social/.well-known/nostr.json?name=bob",
+        url: "http://nos.social/api/names/bob",
         method: "DELETE",
       });
     });
 
     it("should be possible to delete an entry with correct credentials using the @ format", async () => {
       await request(app)
-        .delete("/.well-known/nostr.json")
+        .delete("/api/names/bob")
         .set("Host", "nos.social")
         .set("Authorization", `Nostr ${nip98DeleteAuthToken}`)
-        .query({ name: "bob" })
         .expect(200);
 
       await request(app)
@@ -210,19 +209,18 @@ describe("Nostr NIP 05 API tests", () => {
 
     it("should be possible to delete an entry with correct credentials using the domain format", async () => {
       const nip98DeleteAuthTokenDomain = await getNip98AuthToken({
-        url: "http://bob.nos.social/.well-known/nostr.json?name=_",
+        url: "http://bob.nos.social/api/names/_",
         method: "DELETE",
       });
 
       await request(app)
-        .delete("/.well-known/nostr.json")
+        .delete("/api/names/_")
         .set("Host", "bob.nos.social")
         .set("Authorization", `Nostr ${nip98DeleteAuthTokenDomain}`)
-        .query({ name: "_" })
         .expect(200);
 
       await request(app)
-        .get("/.well-known/nostr.json")
+        .get("/api/names")
         .set("Host", "nos.social")
         .query({ name: "bob" })
         .expect(404);
@@ -230,10 +228,9 @@ describe("Nostr NIP 05 API tests", () => {
 
     it("should fail with wrong credentials", async () => {
       await request(app)
-        .delete("/.well-known/nostr.json")
+        .delete("/api/names/bob")
         .set("Host", "nos.social")
         .set("Authorization", `Nostr ${nip98PostAuthToken}`)
-        .query({ name: "bob" })
         .expect(401);
     });
   });

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -15,7 +15,7 @@ export const userPubkey =
   "464db1ec23b1a5da9ef3df411ba555276b1af85f069a6aee3e2ce996dda7ae58";
 
 const nip98AuthToken = await getNip98AuthToken({
-  url: "http://nos.social/.well-known/nostr.json",
+  url: "http://nos.social/api/names",
   method: "POST",
 });
 
@@ -32,7 +32,7 @@ describe("Nostr 98 Auth tests", () => {
     const userData = createUserData({ name: "bob" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${nip98AuthToken}`)
       .send(userData)
@@ -43,7 +43,7 @@ describe("Nostr 98 Auth tests", () => {
     const userData = createUserData({ name: "bob" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .send(userData)
       .expect(401);
@@ -54,7 +54,7 @@ describe("Nostr 98 Auth tests", () => {
       kind: 27235,
       created_at: Math.floor(Date.now() / 1000),
       tags: [
-        ["u", "http://nos.social/.well-known/nostr.json"],
+        ["u", "http://nos.social/api/names"],
         ["method", "POST"],
       ],
       content: "",
@@ -68,7 +68,7 @@ describe("Nostr 98 Auth tests", () => {
     const userData = createUserData({ name: "bob" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${nip98InvalidAuthToken}`)
       .send(userData)
@@ -77,14 +77,14 @@ describe("Nostr 98 Auth tests", () => {
 
   it("should fail to post with wrong pubkey", async () => {
     const authToken = await getNip98AuthToken({
-      url: "http://nos.social/.well-known/nostr.json",
+      url: "http://nos.social/api/names",
       method: "POST",
       secret: servicePubkeySecret.replace("1", "2"),
     });
     const userData = createUserData({ name: "bob" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${authToken}`)
       .send(userData)
@@ -93,14 +93,14 @@ describe("Nostr 98 Auth tests", () => {
 
   it("should not fail to POST if the pubkey used for auth is the same that is being changed", async () => {
     const authToken = await getNip98AuthToken({
-      url: "http://nos.social/.well-known/nostr.json",
+      url: "http://nos.social/api/names",
       method: "POST",
       secret: userPrivateKey,
     });
     const userData = createUserData({ name: "bob", pubkey: userPubkey });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${authToken}`)
       .send(userData)
@@ -109,13 +109,13 @@ describe("Nostr 98 Auth tests", () => {
 
   it("should fail to post with wrong method", async () => {
     const authToken = await getNip98AuthToken({
-      url: "http://nos.social/.well-known/nostr.json",
+      url: "http://nos.social/api/names",
       method: "GET",
     });
     const userData = createUserData({ name: "bob" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${authToken}`)
       .send(userData)
@@ -124,13 +124,13 @@ describe("Nostr 98 Auth tests", () => {
 
   it("should fail to post with wrong url", async () => {
     const authToken = await getNip98AuthToken({
-      url: "http://wrong.nos.social/.well-known/nostr.json",
+      url: "http://wrong.nos.social/api/names",
       method: "POST",
     });
     const userData = createUserData({ name: "bob" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${authToken}`)
       .send(userData)
@@ -139,28 +139,27 @@ describe("Nostr 98 Auth tests", () => {
 
   it("should not fail to DELETE if the pubkey mapped to the selected name is matching the auth pubkey", async () => {
     const postAuthToken = await getNip98AuthToken({
-      url: "http://nos.social/.well-known/nostr.json",
+      url: "http://nos.social/api/names",
       method: "POST",
       secret: userPrivateKey,
     });
     const userData = createUserData({ name: "bob", pubkey: userPubkey });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${postAuthToken}`)
       .send(userData)
       .expect(200);
 
     const deleteAuthToken = await getNip98AuthToken({
-      url: "http://nos.social/.well-known/nostr.json?name=bob",
+      url: "http://nos.social/api/names/bob",
       method: "DELETE",
       secret: userPrivateKey,
     });
 
     await request(app)
-      .delete("/.well-known/nostr.json")
-      .query({ name: "bob" })
+      .delete("/api/names/bob")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${deleteAuthToken}`)
       .expect(200);
@@ -169,7 +168,7 @@ describe("Nostr 98 Auth tests", () => {
   it("should fail if the event is too old", async () => {
     const yesterday = new Date().getDate() - 1;
     const authToken = await getNip98AuthToken({
-      url: "http://nos.social/.well-known/nostr.json",
+      url: "http://nos.social/api/names",
       method: "POST",
       eventModifier: (event) => {
         event.created_at = yesterday;
@@ -180,7 +179,7 @@ describe("Nostr 98 Auth tests", () => {
     const userData = createUserData({ name: "bob" });
 
     await request(app)
-      .post("/.well-known/nostr.json")
+      .post("/api/names")
       .set("Host", "nos.social")
       .set("Authorization", `Nostr ${authToken}`)
       .send(userData)


### PR DESCRIPTION
This addresses some feedback from Filip so that we rename the post and delete endpoints so that we don't reuse the well-known url. This way it's a more standard way of dealing with this type of endpoint.

Closes #2 