### PR TITLE
Dev environment and image building workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ node_modules/
 .env
 .env.local
 .env.test
+.envrc
+.direnv
+.data
 
 logs/
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 RUN npm install -g pnpm
 

--- a/flake-modules/devshell.nix
+++ b/flake-modules/devshell.nix
@@ -1,0 +1,31 @@
+{ inputs, ... }: {
+  imports = [
+   inputs.devshell.flakeModule
+  ];
+
+  perSystem = { config,pkgs, ...}: {
+    devshells.default = {
+      name = "nip05api-devshell";
+      env = [
+        {name = "NODE_ENV"; value = "development";}
+        {name = "AUTH_PUBKEY"; value = "6c815df9b3e7f43492c232aba075b5fa5b6a60b731ce6ccfc7c1e8bd2adcceb2";}
+        {name = "ROOT_DOMAIN"; value = "nos.social";}
+        {name = "REDIS_HOST"; value = "localhost";}
+      ];
+      commands = [
+        {
+          name = "tt";
+          help = "runs test suite in test environment";
+          category = "app commands";
+          command = ''NODE_ENV=test pnpm test'';
+        }
+        { package = config.packages.nodejs; category = "packages"; }
+        { package = config.packages.pnpm; category = "packages"; }
+        { package = pkgs.redis; category = "packages"; }
+      ];
+      serviceGroups.redis = {
+        services.redis.command = "redis-server --loglevel notice";
+      };
+    };
+  };
+}

--- a/flake-modules/packages.nix
+++ b/flake-modules/packages.nix
@@ -1,0 +1,6 @@
+{
+  perSystem = { pkgs, system, ... }: {
+    packages.nodejs = pkgs.nodejs_18;
+    packages.pnpm = pkgs.nodePackages.pnpm;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,117 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1705332421,
+        "narHash": "sha256-USpGLPme1IuqG78JNqSaRabilwkCyHmVWY0M9vYyqEA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "83cb93d6d063ad290beee669f4badf9914cc16ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1705697961,
+        "narHash": "sha256-XepT3WS516evSFYkme3GrcI3+7uwXHqtHbip+t24J7E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e5d1c87f5813afde2dda384ac807c57a105721cc",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "process-compose": {
+      "locked": {
+        "lastModified": 1705650762,
+        "narHash": "sha256-kSLMsz0tXc1N5Jx8ghEXhLmK4X3Bktt3S4ttXJXCzCo=",
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "rev": "c8942208e7c7122aef4811a606f7c12ad0753a98",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "process-compose": "process-compose"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+    devshell = {
+      url = "github:numtide/devshell";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs@{self, nixpkgs, flake-parts, devshell, process-compose }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      imports = [
+        ./flake-modules/packages.nix
+        ./flake-modules/devshell.nix
+      ];
+    };
+}


### PR DESCRIPTION
This PR adds a dev environment designed to work with [nix flakes and direnv](https://determinate.systems/posts/nix-direnv).  If you have nix, with flakes, installed on your system, then you can navigate to this repo and run:
```
nix develop
```

which will drop you into a shell with node18, pnpm, and redis installed.  You can then run:
```
redis:start
```
to start up a sample redis service.  It also has a shortcut with `tt` that will run the test suite.

The PR also adds a gh actions workflow for building and publishing images based on the existing Dockerfile.  At the moment, this workflow would push to my dockerhub repository as this repo is private.  We can either make the repo public or adjust the settings so the packages are public, at which point we can push to ghcr.io instead.