### PR TITLE
Ensure req.protocol works after ssl termination

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,8 @@ const metricsMiddleware = promBundle({
   includeDefaultMetrics: true,
 });
 
+app.set('trust proxy', true);
+
 app.use(json());
 app.use(cors());
 

--- a/src/middlewares/nip98Auth.js
+++ b/src/middlewares/nip98Auth.js
@@ -16,6 +16,11 @@ export default function nip98Auth(customRule) {
       );
     }
 
+
+    if (req.headers['x-forwarded-proto'] === 'https') {
+      req.protocol = 'https';
+    }
+
     const fullUrl =
       `${req.protocol}` + "://" + `${req.get("host")}${req.originalUrl}`;
     const event = await nip98.unpackEventFromToken(authHeader);


### PR DESCRIPTION
We need to correctly fetch the original protocol to match with the auth request scheme. If we don't do this then traefik ssl termination will send the request as http which is not the original request format