### PR TITLE
pin redis version in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 
 services:
   redis:
-    image: redis
+    image: redis:7.2.4
     ports:
       - "6379:6379"
     command: redis-server --loglevel notice


### PR DESCRIPTION
this uses the same version as in production.

